### PR TITLE
Getting Started: fix the link to the Spresso theme

### DIFF
--- a/src/content/docs/getting-started.md
+++ b/src/content/docs/getting-started.md
@@ -64,7 +64,7 @@ Lets create a sample site and build it. With Spress executable, you have two opt
 1. To scaffold a blank site.
 2. To use a base theme.
 
-Lets create our site using [Spresso](https://github.com/yosymfony/Spress-theme-spresso/tree/2.0) theme:
+Lets create our site using [Spresso](https://github.com/yosymfony/Spress-theme-spresso/tree/2.1) theme:
 
 <div class="panel panel-default">
   <div class="panel-body">


### PR DESCRIPTION
The link was to the `2.0` branch. It seems that's been replaced by `2.1`.